### PR TITLE
In client mode, use hardcoded TLSv1 instead of hardcoded SSLv3.

### DIFF
--- a/doc/stunnel.8
+++ b/doc/stunnel.8
@@ -370,7 +370,9 @@ A colon delimited list of the ciphers to allow in the \s-1SSL\s0 connection.
 For example \s-1DES\-CBC3\-SHA:IDEA\-CBC\-MD5\s0
 .IP "\fBclient\fR = yes | no" 4
 .IX Item "client = yes | no"
-client mode (remote service uses \s-1SSL\s0)
+client mode (remote service uses \s-1TLS\s0)
+.Sp
+(Client mode forces TLSv1 not SSLv2 or SSLv3; this is hardcoded.)
 .Sp
 default: no (server mode)
 .IP "\fBconnect\fR = [host:]port" 4

--- a/doc/stunnel.html
+++ b/doc/stunnel.html
@@ -428,7 +428,10 @@ For example DES-CBC3-SHA:IDEA-CBC-MD5</p>
 <dt><strong><a name="item_client__3d_yes__7c_no"><strong>client</strong> = yes | no</a></strong><br />
 </dt>
 <dd>
-client mode (remote service uses SSL)
+client mode (remote service uses TLS)
+</dd>
+<dd>
+(Client mode forces TLSv1 not SSLv2 or SSLv3; this is hardcoded.)
 </dd>
 <dd>
 <p>default: no (server mode)</p>

--- a/doc/stunnel.pod
+++ b/doc/stunnel.pod
@@ -306,7 +306,9 @@ For example DES-CBC3-SHA:IDEA-CBC-MD5
 
 =item B<client> = yes | no
 
-client mode (remote service uses SSL)
+client mode (remote service uses TLS)
+
+(Client mode forces TLSv1 not SSLv2 or SSLv3; this is hardcoded.)
 
 default: no (server mode)
 

--- a/src/ctx.c
+++ b/src/ctx.c
@@ -80,7 +80,7 @@ SSL_CTX *context_init(LOCAL_OPTIONS *section) { /* init SSL context */
     }
     /* create SSL context */
     if(section->option.client) {
-        ctx=SSL_CTX_new(SSLv3_client_method());
+        ctx=SSL_CTX_new(TLSv1_client_method());
     } else { /* Server mode */
         ctx=SSL_CTX_new(SSLv23_server_method());
 #ifndef NO_RSA


### PR DESCRIPTION
As well as the behaviour change, the English documentation
(but not the French or Polish) is updated to state that the
protocol for client-mode is hardcoded and that it is TLSv1.

Signed-off-by: Thomas Sanders thomas.sanders@citrix.com
